### PR TITLE
ガイドの変更内容を反映

### DIFF
--- a/MessagingServer~/index.ts
+++ b/MessagingServer~/index.ts
@@ -69,7 +69,16 @@ io.on("connection", async (socket: Socket) => {
             log(() => `join: clientId=${socket.id}, groupName=${groupName}`);
             await socket.join(groupName);
             callback("approved");
-            socket.to(groupName).emit("client joined", socket.id);
+            const members = rooms().get(groupName);
+            if (members) {
+                for (const member of members) {
+                    if (member === socket.id) {
+                        continue;
+                    }
+                    socket.to(member).emit("client joined", socket.id);
+                    socket.emit("client joined", member);
+                }
+            }
         }
     );
 

--- a/Runtime/WebGLSocketIOMessagingClient.cs
+++ b/Runtime/WebGLSocketIOMessagingClient.cs
@@ -37,7 +37,6 @@ namespace Extreal.Integration.Messaging.Socket.IO
             WebGLHelper.CallAction(WithPrefix(nameof(WebGLSocketIOMessagingClient)), JsonSocketIOMessagingConfig.ToJson(messagingConfig), instanceId);
             WebGLHelper.AddCallback(WithPrefix(nameof(ReceiveGroupListResponse)), ReceiveGroupListResponse);
             WebGLHelper.AddCallback(WithPrefix(nameof(ReceiveJoinResponse)), ReceiveJoinResponse);
-            WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnLeaving)), HandleOnLeaving);
             WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnUnexpectedLeft)), HandleOnUnexpectedLeft);
             WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnClientJoined)), HandleOnClientJoined);
             WebGLHelper.AddCallback(WithPrefix(nameof(HandleOnClientLeaving)), HandleOnClientLeaving);
@@ -53,11 +52,6 @@ namespace Extreal.Integration.Messaging.Socket.IO
         [MonoPInvokeCallback(typeof(Action<string, string>))]
         private static void ReceiveJoinResponse(string joinResponse, string instanceId)
             => Instances[instanceId].joinResponse = JsonSerializer.Deserialize<WebGLJoinResponse>(joinResponse);
-
-
-        [MonoPInvokeCallback(typeof(Action<string, string>))]
-        private static void HandleOnLeaving(string reason, string instanceId)
-            => Instances[instanceId].FireOnLeaving(reason);
 
         [MonoPInvokeCallback(typeof(Action<string, string>))]
         private static void HandleOnUnexpectedLeft(string reason, string instanceId)

--- a/WebScripts~/package.json
+++ b/WebScripts~/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@extreal-dev/extreal.integration.messaging.socket.io",
-  "version": "1.0.0-next.1",
+  "version": "1.0.0-next.2",
   "scripts": {
     "dev": "rollup --config rollup.config.ts --configPlugin typescript",
     "prod": "rollup --config rollup.config.ts --configPlugin typescript --environment BUILD:production"
@@ -31,7 +31,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@extreal-dev/extreal.integration.web.common": "1.1.0-next.2",
+    "@extreal-dev/extreal.integration.web.common": "1.1.0-next.3",
     "socket.io-client": "4.7.4"
   }
 }

--- a/WebScripts~/src/SocketIOMessagingAdapter.ts
+++ b/WebScripts~/src/SocketIOMessagingAdapter.ts
@@ -13,7 +13,6 @@ class SocketIOMessagingAdapter {
       this.socketIOMessagingClients.set(
         instanceId,
         new SocketIOMessagingClient(socketIOMessagingConfig, {
-          onLeaving: (reason) => callback(this.withPrefix("HandleOnLeaving"), reason, instanceId),
           onUnexpectedLeft: (reason) =>
             callback(this.withPrefix("HandleOnUnexpectedLeft"), reason, instanceId),
           onClientJoined: (clientId) => callback(this.withPrefix("HandleOnClientJoined"), clientId, instanceId),

--- a/WebScripts~/src/SocketIOMessagingClient.ts
+++ b/WebScripts~/src/SocketIOMessagingClient.ts
@@ -27,7 +27,6 @@ type Message = {
 };
 
 type SocketIOMessagingClientCallbacks = {
-  onLeaving: (reason: string) => void;
   onUnexpectedLeft: (reason: string) => void;
   onClientJoined: (clientId: string) => void;
   onClientLeaving: (clientId: string) => void;
@@ -142,11 +141,6 @@ class SocketIOMessagingClient {
       console.log(`Receive disconnect: reason=${reason}`);
     }
     this.callbacks.onUnexpectedLeft(reason);
-  };
-
-  public receiveDeleteGroup = () => {
-    this.callbacks.onLeaving("delete group");
-    this.stopSocket();
   };
 
   private receiveClientJoined = (clientId: string) => {

--- a/WebScripts~/yarn.lock
+++ b/WebScripts~/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@extreal-dev/extreal.integration.web.common@1.1.0-next.2":
-  version "1.1.0-next.2"
-  resolved "https://registry.yarnpkg.com/@extreal-dev/extreal.integration.web.common/-/extreal.integration.web.common-1.1.0-next.2.tgz#752a8c9b89a4d92e49220b75cf39cb7070434a03"
-  integrity sha512-1xnnY+qGaL48bKy9X+ZStEO2yQ7xku4ChHvrADmtyFYlUMV2bhZUyxLkGrljFRp2qmor488AU29/UK5AibfkaQ==
+"@extreal-dev/extreal.integration.web.common@1.1.0-next.3":
+  version "1.1.0-next.3"
+  resolved "https://registry.yarnpkg.com/@extreal-dev/extreal.integration.web.common/-/extreal.integration.web.common-1.1.0-next.3.tgz#bd277a92f7b262c6882e57fc19704884ec2649a2"
+  integrity sha512-NO3d65FG47yigviEmm+qpEQEGAEUNRRrIC0Rx43c98a1OOayQ1EKC8qz7I8IWrTm5BXbYYyher9xs/x06/tgMg==
 
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jp.co.tis.extreal.integration.messaging.socket.io",
-  "version": "1.0.0-next.5",
+  "version": "1.0.0-next.6",
   "displayName": "Extreal.Integration.Messaging.Socket.IO",
   "unity": "2022.3",
   "author": {
@@ -11,7 +11,8 @@
     "com.neuecc.unirx": "7.1.0",
     "jp.co.tis.extreal.core.logging": "1.2.0",
     "jp.co.tis.extreal.core.common": "1.2.0-next.1",
-    "jp.co.tis.extreal.integration.messaging": "1.0.0-next.3"
+    "jp.co.tis.extreal.integration.messaging": "1.0.0-next.4",
+    "jp.co.tis.extreal.integration.web.common": "1.1.0-next.3"
   },
   "samples": [
     {


### PR DESCRIPTION
# 何の変更を加えましたか？

- LeavingReason を削除しました
- 新しくグループに参加したクライアントが既に参加しているクライアントの ID を受け取れない問題を解消しました
- `Web.Common` および `Messaging` のバージョンを上げました

# 何を確認しましたか?

## 実装

- [x] Frameworkの誤った使い方にすぐに気づけるように、無効な引数や無効なメソッド呼び出しに対するチェックが入っていることを確認しました
- [x] Framework実行時の動きが分かるように、ログ（Error/Warn/Info/Debug）を出力していることを確認しました
- [x] 静的解析で問題が見つからないことを確認しました
- [x] フレームワーク利用者が使うAPI（主にprivate以外）に C# ドキュメントを記述しました

## テスト

- [x] 全ての自動テストが成功することを確認しました
- [x] テストカバレッジが100%になることを確認しました
- [x] サンプルがあるものはサンプルが動作することを確認しました

## 変更影響

https://github.com/extreal-dev/Extreal.Guide/pull/56
- [x] GuideのReleaseページに変更内容が追加されることを確認しました
- [ ] GuideのModuleページ（機能ページ）に変更が反映されることを確認しました
- [x] GuideのLearningページに変更が反映されることを確認しました
- [x] Sample Applicationに変更が反映されることを確認しました

# レビュアーへのメッセージ
